### PR TITLE
改进ticks溢出前后调度时间的准确度，及其他一些优化

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CC   = gcc.exe 
+CC   = gcc
 OBJ  = main.o 
 LINKOBJ  = $(OBJ) $(RESOBJ)
 DEFS =


### PR DESCRIPTION
- 让ticks在整型溢出附近调度任务的时间间隔更准确
- 只对en为1的任务进行调度与否的判断和时间计算，节省一点点CPU
- 调用`zt_start`时，让任务能在下一轮被调度，达到立即执行的结果
- 将Makefile中的`gcc.exe`改为`gcc`，在Linux和msys/mingw环境中都可编译
- 在`for`和`if`后面加上空格，使其符合大多数lint工具的默认编码风格